### PR TITLE
Fix typo on instance variable.

### DIFF
--- a/lib/catcher/service/em/http.rb
+++ b/lib/catcher/service/em/http.rb
@@ -14,7 +14,7 @@ module Catcher
         end
 
         def response
-          @repsonse ||= Encoder.encode(request.response)
+          @response ||= Encoder.encode(request.response)
         end
 
         def options


### PR DESCRIPTION
Just noticed this. Not sure if we have any client code consuming `@repsonse` though.
