### PR TITLE
Feature/ecoding for non ascii chars

### DIFF
--- a/lib/catcher/encoder.rb
+++ b/lib/catcher/encoder.rb
@@ -1,37 +1,5 @@
 class Encoder
-  def initialize(string)
-    @string = string
-  end
-
   def self.encode(string)
-    new(string).encode
-  end
-
-  def encode
-    native? ? native : iconv
-  end
-
-  private
-  attr_reader :string
-
-  def native?
-    encodable? && !ascii?
-  end
-
-  def ascii?
-    string.encoding.to_s.include?('ASCII')
-  end
-
-  def encodable?
-    string.respond_to?(:encode!)
-  end
-
-  def native
-    string.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
-  end
-
-  def iconv
-    require 'iconv'
-    ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', string + ' ')[0..-2]
+    string.force_encoding('UTF-8')
   end
 end

--- a/spec/lib/catcher/encoder_spec.rb
+++ b/spec/lib/catcher/encoder_spec.rb
@@ -1,11 +1,32 @@
+#-*- coding: utf-8 -*-
+
 require 'spec_helper'
+require 'json'
 
 describe Encoder do
+  subject { described_class.encode(string)  }
 
-  let(:encoder) { Encoder.encode(string)  }
-  let(:string) { 'test' }
+  let(:original) { { name: name }.to_json }
+  let(:name) { 'äåéöÄÅÉÖabcdef123098%^&*()%$£"!η./?_`¬Π π' }
+  let(:string) { original }
 
   it 'returns a string' do
-    expect(encoder).to eq string
+    expect(subject).to be_an_instance_of(String)
+  end
+
+  context 'when passed a UTF8 string' do
+    let(:string) { original.dup.force_encoding('UTF-8') }
+
+    it 'returns given string' do
+      expect(subject).to eq(original)
+    end
+  end
+
+  context 'when passed an ASCII string' do
+    let(:string) { original.dup.force_encoding('ASCII') }
+
+    it 'returns a UTF8 string' do
+      expect(subject).to eq(original)
+    end
   end
 end


### PR DESCRIPTION
String#encode is not executed if the string has the same encoding of the argument, even if it contains invalid chars. In those occasions the iconv library was used to force the conversion anyway.

This removes the deprecated (removed) iconv library and uses only the standard ruby library method `force_encoding` method which does force the conversion anyway.
