### PR TITLE
Feature/encoding for non utf8 chars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
+  - 1.8.7
   - rbx-19mode

--- a/lib/catcher/encoder.rb
+++ b/lib/catcher/encoder.rb
@@ -1,10 +1,37 @@
 class Encoder
+  def initialize(string)
+    @string = string
+  end
+
   def self.encode(string)
-    if string.respond_to?(:encode!)
-      string.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
-    else
-      require 'iconv'
-      ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', string + ' ')[0..-2]
-    end
+    new(string).encode
+  end
+
+  def encode
+    native? ? native : iconv
+  end
+
+  private
+  attr_reader :string
+
+  def native?
+    encodable? && !ascii?
+  end
+
+  def ascii?
+    string.encoding.to_s.include?('ASCII')
+  end
+
+  def encodable?
+    string.respond_to?(:encode!)
+  end
+
+  def native
+    string.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
+  end
+
+  def iconv
+    require 'iconv'
+    ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', string + ' ')[0..-2]
   end
 end

--- a/spec/lib/catcher/encoder_spec.rb
+++ b/spec/lib/catcher/encoder_spec.rb
@@ -1,11 +1,32 @@
+#-*- coding: utf-8 -*-
+
 require 'spec_helper'
+require 'json'
 
 describe Encoder do
+  subject { described_class.encode(string)  }
 
-  let(:encoder) { Encoder.encode(string)  }
-  let(:string) { 'test' }
+  let(:original) { { name: name }.to_json }
+  let(:name) { 'äåéöÄÅÉÖabcdef123098%^&*()%$£"!¿./?_`¬¿ ¿' }
+  let(:string) { original }
 
   it 'returns a string' do
-    expect(encoder).to eq string
+    expect(subject).to be_an_instance_of(String)
+  end
+
+  context 'when passed a UTF8 string' do
+    let(:string) { original.dup.force_encoding('UTF-8') }
+
+    it 'returns given string' do
+      expect(subject).to eq(original)
+    end
+  end
+
+  context 'when passed an ASCII string' do
+    let(:string) { original.dup.force_encoding('ASCII') }
+
+    it 'returns a UTF8 string' do
+      expect(subject).to eq(original)
+    end
   end
 end


### PR DESCRIPTION
Update encoder to deal with different inputs.
Force usage of iconv for not utf-8 strings.
Also update travis to include ruby 1.8.7
