### PR TITLE
Enable the use of headers when generating a HTTP request

### DIFF
--- a/lib/catcher/api.rb
+++ b/lib/catcher/api.rb
@@ -37,5 +37,10 @@ module Catcher
       # optional, include to set expires_in per endpoint
       # 500
     end
+
+    def headers
+      {}
+    end
+
   end
 end

--- a/lib/catcher/cache.rb
+++ b/lib/catcher/cache.rb
@@ -29,7 +29,7 @@ module Catcher
     attr_reader :api
 
     def parsed_api_response
-      @parsed_api_response ||= Service.factory(api_resource).parsed_api_response
+      @parsed_api_response ||= Service.factory(api_resource, headers).parsed_api_response
     end
 
     def root_key
@@ -59,6 +59,10 @@ module Catcher
 
     def cache(response)
       store.set(cache_key, response, ttl) if cacheable?
+    end
+
+    def headers
+      api.headers
     end
   end
 end

--- a/lib/catcher/service/em/http.rb
+++ b/lib/catcher/service/em/http.rb
@@ -5,8 +5,9 @@ module Catcher
     module EM
       class Http
 
-        def initialize(url)
+        def initialize(url, headers)
           @url = url
+          @headers = headers
         end
 
         def parsed_api_response
@@ -25,7 +26,7 @@ module Catcher
         end
 
         def request
-          EventMachine::HttpRequest.new(@url, options).get
+          EventMachine::HttpRequest.new(@url, options).get(:head => @headers)
         end
       end
 

--- a/lib/catcher/service/net/http.rb
+++ b/lib/catcher/service/net/http.rb
@@ -6,8 +6,9 @@ module Catcher
     module Net
       class Http
 
-        def initialize(url)
+        def initialize(url, headers)
           @url = url
+          @headers = headers
         end
 
         def parsed_api_response
@@ -19,8 +20,9 @@ module Catcher
         end
 
         def request
-          ::Net::HTTP::Get.new(url).tap do |request|
+          ::Net::HTTP::Get.new(uri.request_uri).tap do |request|
             request['Content-Type'] = 'application/json'
+            @headers.each { |k,v| request[k] = v }
           end
         end
 

--- a/spec/lib/catcher/cache_spec.rb
+++ b/spec/lib/catcher/cache_spec.rb
@@ -108,9 +108,10 @@ module Catcher
         let(:response) { {:example => example} }
         let(:resource) { 'http://example.com/en/1' }
         let(:service) { stub }
+        let(:headers) { { 'Authorization' => 'XYZ' } }
 
         before do
-          service_class.expects(:new).with(resource).returns(service)
+          service_class.expects(:new).with(resource, headers).returns(service)
           service.expects(:parsed_api_response).returns(response)
         end
 

--- a/spec/lib/catcher/service/em/http_spec.rb
+++ b/spec/lib/catcher/service/em/http_spec.rb
@@ -12,7 +12,9 @@ module Catcher
 
     describe Service::EM::Http do
       let(:url) { stub }
-      let(:service) { Service::EM::Http.new(url) }
+      let(:headers) { { 'Authorization' => 'XYZ' } }
+      let(:service) { Service::EM::Http.new(url, headers) }
+
       describe "#new" do
         it "takes a url" do
           service
@@ -63,7 +65,7 @@ module Catcher
 
         before do
           EventMachine::HttpRequest.expects(:new).with(url, service.options).returns(request)
-          request.expects(:get).returns(response)
+          request.expects(:get).with(:head => headers).returns(response)
         end
 
         it "makes a request" do

--- a/spec/lib/catcher/service/net/http_spec.rb
+++ b/spec/lib/catcher/service/net/http_spec.rb
@@ -13,7 +13,8 @@ module Catcher
       let(:url)  { stub }
       let(:host) { stub }
       let(:uri)  { stub(:host => host) }
-      let(:service) { Service::Net::Http.new(url) }
+      let(:headers) { {} }
+      let(:service) { Service::Net::Http.new(url, headers) }
 
       before do
         service.stubs(URI: uri)
@@ -71,11 +72,24 @@ module Catcher
         let(:response) { stub }
         let(:request) { stub }
         let(:http) { stub }
+        let(:request_uri) { '/example/abc' }
 
         before do
-          ::Net::HTTP::Get.expects(:new).with(url).returns(request)
+          uri.stubs(:request_uri).returns(request_uri)
+          ::Net::HTTP::Get.expects(:new).with(uri.request_uri).returns(request)
           request.expects(:[]=).with('Content-Type', 'application/json')
+        end
 
+        context 'with headers' do
+          let(:headers) { { 'Authorization' => 'XYZ' } }
+
+          before do
+            request.expects(:[]=).with('Authorization', 'XYZ')
+          end
+
+          it 'makes a request with headers included' do
+            expect(service.request).to eq request
+          end
         end
 
         it "makes a request" do

--- a/spec/support/dummy_class.rb
+++ b/spec/support/dummy_class.rb
@@ -22,6 +22,10 @@ class DummyClass < Catcher::API
   def expires_in
     500
   end
+
+  def headers
+    { 'Authorization' => 'XYZ' }
+  end
 end
 
 class CacheApi < DummyClass


### PR DESCRIPTION
Previously, there was no way of passing through custom headers when using Catcher. This meant that when hitting some third-party API's which require authentication, we would always get back a 403 Unauthorised.

This commit addresses this by allowing an inheriting class of 'Catcher::API' to specify its own 'header' method, which will contain their required headers.