### PR TITLE
Allow timeout time to be overwritten

### DIFF
--- a/lib/catcher/api.rb
+++ b/lib/catcher/api.rb
@@ -42,5 +42,15 @@ module Catcher
       {}
     end
 
+    def open_timeout
+      # optional, include to set amount of time to wait for connection
+      20
+    end
+
+    def read_timeout
+      # optional, include to set amount of time to wait for response
+      20
+    end
+
   end
 end

--- a/lib/catcher/cache.rb
+++ b/lib/catcher/cache.rb
@@ -29,7 +29,7 @@ module Catcher
     attr_reader :api
 
     def parsed_api_response
-      @parsed_api_response ||= Service.factory(api_resource, headers).parsed_api_response
+      @parsed_api_response ||= Service.factory(api).parsed_api_response
     end
 
     def root_key

--- a/lib/catcher/service/em/http.rb
+++ b/lib/catcher/service/em/http.rb
@@ -4,10 +4,11 @@ module Catcher
   module Service
     module EM
       class Http
+        attr_reader :api
+        private :api
 
-        def initialize(url, headers)
-          @url = url
-          @headers = headers
+        def initialize(api)
+          @api = api
         end
 
         def parsed_api_response
@@ -20,13 +21,14 @@ module Catcher
 
         def options
           {
-            :connect_timeout => 20,
-            :inactivity_timeout => 20
+            connect_timeout: api.open_timeout,
+            inactivity_timeout: api.read_timeout
           }
         end
 
         def request
-          EventMachine::HttpRequest.new(@url, options).get(:head => @headers)
+          EventMachine::HttpRequest.new(api.resource, options).
+            get(head: api.headers)
         end
       end
 

--- a/lib/catcher/service/net/http.rb
+++ b/lib/catcher/service/net/http.rb
@@ -5,10 +5,11 @@ module Catcher
   module Service
     module Net
       class Http
+        attr_reader :api
+        private :api
 
-        def initialize(url, headers)
-          @url = url
-          @headers = headers
+        def initialize(api)
+          @api = api
         end
 
         def parsed_api_response
@@ -22,12 +23,12 @@ module Catcher
         def request
           ::Net::HTTP::Get.new(uri.request_uri).tap do |request|
             request['Content-Type'] = 'application/json'
-            @headers.each { |k,v| request[k] = v }
+            api.headers.each { |k,v| request[k] = v }
           end
         end
 
         def uri
-          URI(url)
+          URI(api.resource)
         end
 
         private
@@ -35,8 +36,8 @@ module Catcher
         def http
           ::Net::HTTP.new(uri.host, uri.port).tap do |http|
             http.use_ssl = uri.scheme == 'https'
-            http.open_timeout = 20
-            http.read_timeout = 20
+            http.open_timeout = api.open_timeout
+            http.read_timeout = api.read_timeout
           end
         end
 

--- a/spec/lib/catcher/cache_spec.rb
+++ b/spec/lib/catcher/cache_spec.rb
@@ -111,7 +111,7 @@ module Catcher
         let(:headers) { { 'Authorization' => 'XYZ' } }
 
         before do
-          service_class.expects(:new).with(resource, headers).returns(service)
+          service_class.expects(:new).with(api).returns(service)
           service.expects(:parsed_api_response).returns(response)
         end
 

--- a/spec/lib/catcher/service/em/http_spec.rb
+++ b/spec/lib/catcher/service/em/http_spec.rb
@@ -11,9 +11,14 @@ module Catcher
     end
 
     describe Service::EM::Http do
-      let(:url) { stub }
+      let(:resource) { stub }
       let(:headers) { { 'Authorization' => 'XYZ' } }
-      let(:service) { Service::EM::Http.new(url, headers) }
+      let(:api) {
+        stub('Api', resource: resource, headers: headers, open_timeout: 20, read_timeout: 20)
+      }
+      let(:service) {
+        Service::EM::Http.new(api)
+      }
 
       describe "#new" do
         it "takes a url" do
@@ -64,7 +69,7 @@ module Catcher
         let(:request) { stub }
 
         before do
-          EventMachine::HttpRequest.expects(:new).with(url, service.options).returns(request)
+          EventMachine::HttpRequest.expects(:new).with(resource, service.options).returns(request)
           request.expects(:get).with(:head => headers).returns(response)
         end
 

--- a/spec/lib/catcher/service/net/http_spec.rb
+++ b/spec/lib/catcher/service/net/http_spec.rb
@@ -10,11 +10,16 @@ module Catcher
     end
 
     describe Service::Net::Http do
-      let(:url)  { stub }
+      let(:resource)  { stub }
       let(:host) { stub }
       let(:uri)  { stub(:host => host) }
       let(:headers) { {} }
-      let(:service) { Service::Net::Http.new(url, headers) }
+      let(:api) {
+        stub('Api', resource: resource, headers: headers, open_timeout: 20, read_timeout: 20)
+      }
+      let(:service) {
+        Service::Net::Http.new(api)
+      }
 
       before do
         service.stubs(URI: uri)


### PR DESCRIPTION
At the moment the timeouts for requests are hard coded to 20 seconds. There are instances where we might need this to be less, or more, depending on the situation. This allows for an optional override via API inheritance.